### PR TITLE
luci-app-ssr-plus: only selete ss-rust for armv8 devices

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -17,7 +17,7 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks
 config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust
 	bool "Include Shadowsocks Rust (AEAD ciphers only)"
 	depends on aarch64||arm||i386||mips||mipsel||x86_64
-	default y if x86_64||aarch64
+	default y if aarch64
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray_plugin
 	bool "Include Shadowsocks V2ray Plugin"


### PR DESCRIPTION
ss-libev on x86_64 is good enough.

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>